### PR TITLE
fix: use `ec` library instead of standard library

### DIFF
--- a/.github/NIGHTLY_CANARY_DIED.md
+++ b/.github/NIGHTLY_CANARY_DIED.md
@@ -1,5 +1,6 @@
 ---
 title: "Tests fail on latest Nargo nightly release"
+assignees: TomAFrench, kashbrti, jtriley-eth
 ---
 
 The tests on this Noir project have started failing when using the latest nightly release of the Noir compiler. This likely means that there have been breaking changes for which this project needs to be updated to take into account.

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,3 +5,4 @@ authors = [""]
 compiler_version = ">=0.36.0"
 
 [dependencies]
+ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,7 +1,7 @@
 use std::default::Default;
-use std::ec::consts::te::baby_jubjub;
-use std::ec::tecurve::affine::Point as TEPoint;
 use std::hash::Hasher;
+
+use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
 
 pub fn eddsa_verify<H>(
     pub_key_x: Field,

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -56,10 +56,10 @@ pub fn eddsa_to_pub(secret: Field) -> (Field, Field) {
 }
 
 mod tests {
-    use std::ec::consts::te::baby_jubjub;
-    use std::ec::tecurve::affine::Point as TEPoint;
     use std::hash::poseidon::PoseidonHasher;
     use std::hash::poseidon2::Poseidon2Hasher;
+
+    use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
 
     use super::{eddsa_to_pub, eddsa_verify};
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #3 

## Summary\*

This replaces the usage of the stdlib with https://github.com/noir-lang/ec

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
