### PR TITLE
fix: bump poseidon to v0.1.1

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.36.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
-poseidon = { tag = "v0.1.0", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }


### PR DESCRIPTION
# Description

## Problem

Towards https://github.com/noir-lang/noir/pull/7908

## Summary



## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
