### PR TITLE
feat: Update poseidon version

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.36.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
-poseidon = { tag = "v0.2.5", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { tag = "v0.2.6", git = "https://github.com/noir-lang/poseidon" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.36.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
-poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { tag = "v0.2.4", git = "https://github.com/noir-lang/poseidon" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ compiler_version = ">=0.36.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
-poseidon = { tag = "v0.2.4", git = "https://github.com/noir-lang/poseidon" }
+poseidon = { tag = "v0.2.5", git = "https://github.com/noir-lang/poseidon" }


### PR DESCRIPTION
# Description

## Problem\*

Resolves compiler breakages from https://github.com/noir-lang/noir/pull/11627 by updating poseidon version

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
