### PR TITLE
chore: migrate from ec -> noir-edwards

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,14 +17,12 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.36.0
+          toolchain: 1.0.0-beta.17
 
       - name: Install bb
         run: |
-          npm install -g bbup
-          bbup -nv 0.36.0
-          sudo apt install libc++-dev
-
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
+          ~/.bb/bbup -nv 1.0.0-beta.17
 
       - name: Build Noir benchmark programs
         run: nargo export

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Benchmark library
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,36 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MINIMUM_NOIR_VERSION: v1.0.0-beta.0
 
 jobs:
+  noir-version-list:
+    name: Query supported Noir versions
+    runs-on: ubuntu-latest
+    outputs:
+      noir_versions: ${{ steps.get_versions.outputs.versions }}
+
+    steps:
+      - name: Checkout sources
+        id: get_versions
+        run: |
+          # gh returns the Noir releases in reverse chronological order so we keep all releases published after the minimum supported version.
+          VERSIONS=$(gh release list -R noir-lang/noir --exclude-pre-releases --json tagName -q 'map(.tagName) | index(env.MINIMUM_NOIR_VERSION) as $index | if $index then .[0:$index+1] else [env.MINIMUM_NOIR_VERSION] end')
+          echo "versions=$VERSIONS"
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   test:
+    needs: [noir-version-list]
     name: Test on Nargo ${{matrix.toolchain}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.36.0]
+        toolchain: ${{ fromJson( needs.noir-version-list.outputs.noir_versions )}}
+        include:
+          - toolchain: nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +59,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.36.0
+          toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
 
       - name: Run formatter
         run: nargo fmt --check
@@ -50,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
     if: ${{ always() }}
-    needs: 
+    needs:
       - test
       - format
 

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,7 +2,7 @@
 name = "eddsa"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.36.0"
+compiler_version = ">=1.0.0"
 
 [dependencies]
 edwards = { tag = "v0.2.5", git = "https://github.com/noir-lang/noir-edwards" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.36.0"
 
 [dependencies]
-ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
+edwards = { tag = "v0.2.5", git = "https://github.com/noir-lang/noir-edwards" }
 poseidon = { tag = "v0.2.6", git = "https://github.com/noir-lang/poseidon" }

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -2,7 +2,17 @@ use poseidon;
 use std::default::Default;
 use std::hash::Hasher;
 
-use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
+use edwards::{bjj::BabyJubJub, Curve, CurveTrait, ScalarField};
+
+// Baby JubJub subgroup order
+global SUBORDER: Field =
+    2736030358979909402780800718157159386076813972158567259200215660948447373041;
+
+// Generator * 8
+global BASE8_X: Field =
+    5299619240641551281634865583518297030282874472190772894086521144482721001553;
+global BASE8_Y: Field =
+    16950150798460657717958625567821834550301663161624707787222815936182638968203;
 
 pub fn eddsa_verify<H>(
     pub_key_x: Field,
@@ -17,15 +27,12 @@ where
 {
     // Verifies by testing:
     // S * B8 = R8 + H(R8, A, m) * A8
-    let bjj = baby_jubjub();
 
-    let pub_key = TEPoint::new(pub_key_x, pub_key_y);
-    assert(bjj.curve.contains(pub_key));
-
-    let signature_r8 = TEPoint::new(signature_r8_x, signature_r8_y);
-    assert(bjj.curve.contains(signature_r8));
+    // BabyJubJub::new asserts the point is on the curve
+    let pub_key = BabyJubJub::new(pub_key_x, pub_key_y);
+    let signature_r8 = BabyJubJub::new(signature_r8_x, signature_r8_y);
     // Ensure S < Subgroup Order
-    assert(signature_s.lt(bjj.suborder));
+    assert(signature_s.lt(SUBORDER));
     // Calculate the h = H(R, A, msg)
     let mut hasher = H::default();
     hasher.write(signature_r8_x);
@@ -36,23 +43,23 @@ where
     let hash: Field = hasher.finish();
     // Calculate second part of the right side:  right2 = h*8*A
     // Multiply by 8 by doubling 3 times. This also ensures that the result is in the subgroup.
-    let pub_key_mul_2 = bjj.curve.add(pub_key, pub_key);
-    let pub_key_mul_4 = bjj.curve.add(pub_key_mul_2, pub_key_mul_2);
-    let pub_key_mul_8 = bjj.curve.add(pub_key_mul_4, pub_key_mul_4);
+    let pub_key_mul_2 = pub_key.dbl();
+    let pub_key_mul_4 = pub_key_mul_2.dbl();
+    let pub_key_mul_8 = pub_key_mul_4.dbl();
     // We check that A8 is not zero.
     assert(!pub_key_mul_8.is_zero());
     // Compute the right side: R8 + h * A8
-    let right = bjj.curve.add(signature_r8, bjj.curve.mul(hash, pub_key_mul_8));
+    let right = signature_r8 + pub_key_mul_8.mul(ScalarField::<64>::from(hash));
     // Calculate left side of equation left = S * B8
-    let left = bjj.curve.mul(signature_s, bjj.base8);
+    let base8: BabyJubJub = Curve { x: BASE8_X, y: BASE8_Y };
+    let left = base8.mul(ScalarField::<63>::from(signature_s));
 
-    left.eq(right)
+    left == right
 }
 
 // Returns the public key of the given secret key as (pub_key_x, pub_key_y)
 pub fn eddsa_to_pub(secret: Field) -> (Field, Field) {
-    let bjj = baby_jubjub();
-    let pub_key = bjj.curve.mul(secret, bjj.curve.gen);
+    let pub_key = BabyJubJub::one().mul(ScalarField::<64>::from(secret));
     (pub_key.x, pub_key.y)
 }
 
@@ -60,9 +67,9 @@ mod tests {
     use poseidon::poseidon::PoseidonHasher;
     use poseidon::poseidon2::Poseidon2Hasher;
 
-    use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
+    use edwards::{bjj::BabyJubJub, Curve, CurveTrait, ScalarField};
 
-    use super::{eddsa_to_pub, eddsa_verify};
+    use super::{eddsa_to_pub, eddsa_verify, BASE8_X, BASE8_Y};
 
     #[test]
     fn main() {
@@ -70,52 +77,45 @@ mod tests {
         let priv_key_b = 456;
         let msg = 789;
 
-        let bjj = baby_jubjub();
-
-        let pub_key_a = bjj.curve.mul(priv_key_a, bjj.curve.gen);
-        let pub_key_b = bjj.curve.mul(priv_key_b, bjj.curve.gen);
+        let pub_key_a = BabyJubJub::one().mul(ScalarField::<63>::from(priv_key_a));
+        let pub_key_b = BabyJubJub::one().mul(ScalarField::<63>::from(priv_key_b));
         let (pub_key_a_x, pub_key_a_y) = eddsa_to_pub(priv_key_a);
         let (pub_key_b_x, pub_key_b_y) = eddsa_to_pub(priv_key_b);
-        assert(TEPoint::new(pub_key_a_x, pub_key_a_y) == pub_key_a);
-        assert(TEPoint::new(pub_key_b_x, pub_key_b_y) == pub_key_b);
-        // Manually computed as fields can't use modulo. Importantantly the commitment is within
+        assert(BabyJubJub::new(pub_key_a_x, pub_key_a_y) == pub_key_a);
+        assert(BabyJubJub::new(pub_key_b_x, pub_key_b_y) == pub_key_b);
+        // Manually computed as fields can't use modulo. Importantly the commitment is within
         // the subgroup order. Note that choice of hash is flexible for this step.
-        // let r_a = hash::pedersen_commitment([_priv_key_a, msg])[0] % bjj.suborder; // modulus computed manually
-        let r_a = 1414770703199880747815475415092878800081323795074043628810774576767372531818;
-        // let r_b = hash::pedersen_commitment([_priv_key_b, msg])[0] % bjj.suborder; // modulus computed manually
-        let r_b = 571799555715456644614141527517766533395606396271089506978608487688924659618;
+        let r_a =
+            1414770703199880747815475415092878800081323795074043628810774576767372531818;
+        let r_b =
+            571799555715456644614141527517766533395606396271089506978608487688924659618;
 
-        let r8_a = bjj.curve.mul(r_a, bjj.base8);
-        let r8_b = bjj.curve.mul(r_b, bjj.base8);
-        // let h_a: [Field; 6] = hash::poseidon::bn254::hash_5([
-        //     r8_a.x,
-        //     r8_a.y,
-        //     pub_key_a.x,
-        //     pub_key_a.y,
-        //     msg,
-        // ]);
-        // let h_b: [Field; 6] = hash::poseidon::bn254::hash_5([
-        //     r8_b.x,
-        //     r8_b.y,
-        //     pub_key_b.x,
-        //     pub_key_b.y,
-        //     msg,
-        // ]);
-        // let s_a = (r_a + _priv_key_a * h_a) % bjj.suborder; // modulus computed manually
-        let s_a = 30333430637424319196043722294837632681219980330991241982145549329256671548;
-        // let s_b = (r_b + _priv_key_b * h_b) % bjj.suborder; // modulus computed manually
-        let s_b = 1646085314320208098241070054368798527940102577261034947654839408482102287019;
+        let base8: BabyJubJub = Curve { x: BASE8_X, y: BASE8_Y };
+        let r8_a = base8.mul(ScalarField::<63>::from(r_a));
+        let r8_b = base8.mul(ScalarField::<63>::from(r_b));
+        let s_a =
+            30333430637424319196043722294837632681219980330991241982145549329256671548;
+        let s_b =
+            1646085314320208098241070054368798527940102577261034947654839408482102287019;
         // User A verifies their signature over the message
-        assert(eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg));
+        assert(
+            eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg),
+        );
         // User B's signature over the message can't be used with user A's pub key
-        assert(!eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_b, r8_b.x, r8_b.y, msg));
+        assert(
+            !eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_b, r8_b.x, r8_b.y, msg),
+        );
         // User A's signature over the message can't be used with another message
         assert(
-            !eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg + 1),
+            !eddsa_verify::<PoseidonHasher>(
+                pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg + 1,
+            ),
         );
         // Using a different hash should fail
         assert(
-            !eddsa_verify::<Poseidon2Hasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg),
+            !eddsa_verify::<Poseidon2Hasher>(
+                pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg,
+            ),
         );
     }
 }

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -69,7 +69,7 @@ mod tests {
 
     use edwards::{bjj::BabyJubJub, Curve, CurveTrait, ScalarField};
 
-    use super::{eddsa_to_pub, eddsa_verify, BASE8_X, BASE8_Y};
+    use super::{BASE8_X, BASE8_Y, eddsa_to_pub, eddsa_verify};
 
     #[test]
     fn main() {
@@ -85,37 +85,25 @@ mod tests {
         assert(BabyJubJub::new(pub_key_b_x, pub_key_b_y) == pub_key_b);
         // Manually computed as fields can't use modulo. Importantly the commitment is within
         // the subgroup order. Note that choice of hash is flexible for this step.
-        let r_a =
-            1414770703199880747815475415092878800081323795074043628810774576767372531818;
-        let r_b =
-            571799555715456644614141527517766533395606396271089506978608487688924659618;
+        let r_a = 1414770703199880747815475415092878800081323795074043628810774576767372531818;
+        let r_b = 571799555715456644614141527517766533395606396271089506978608487688924659618;
 
         let base8: BabyJubJub = Curve { x: BASE8_X, y: BASE8_Y };
         let r8_a = base8.mul(ScalarField::<63>::from(r_a));
         let r8_b = base8.mul(ScalarField::<63>::from(r_b));
-        let s_a =
-            30333430637424319196043722294837632681219980330991241982145549329256671548;
-        let s_b =
-            1646085314320208098241070054368798527940102577261034947654839408482102287019;
+        let s_a = 30333430637424319196043722294837632681219980330991241982145549329256671548;
+        let s_b = 1646085314320208098241070054368798527940102577261034947654839408482102287019;
         // User A verifies their signature over the message
-        assert(
-            eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg),
-        );
+        assert(eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg));
         // User B's signature over the message can't be used with user A's pub key
-        assert(
-            !eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_b, r8_b.x, r8_b.y, msg),
-        );
+        assert(!eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_b, r8_b.x, r8_b.y, msg));
         // User A's signature over the message can't be used with another message
         assert(
-            !eddsa_verify::<PoseidonHasher>(
-                pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg + 1,
-            ),
+            !eddsa_verify::<PoseidonHasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg + 1),
         );
         // Using a different hash should fail
         assert(
-            !eddsa_verify::<Poseidon2Hasher>(
-                pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg,
-            ),
+            !eddsa_verify::<Poseidon2Hasher>(pub_key_a.x, pub_key_a.y, s_a, r8_a.x, r8_a.y, msg),
         );
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

https://github.com/noir-lang/ec is a read-only archive. It contains a breaking change after https://github.com/noir-lang/noir/pull/11753. We should migrate to the actively maintained https://github.com/noir-lang/noir-edwards.

## Summary\*

Change `ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }` to `edwards = { tag = "v0.2.5", git = "https://github.com/noir-lang/noir-edwards" }` and apply the appropriate fixes. 

CI updates follow the more up-to-date approach of checking against a min noir version https://github.com/noir-lang/noir-edwards/blob/main/.github/workflows/test.yml. 

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
